### PR TITLE
Add board representation types

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "devDependencies": {
     "ts-jest": "^29.2.5",

--- a/frontend/src/board/README.md
+++ b/frontend/src/board/README.md
@@ -1,0 +1,1 @@
+This subdirectory holds code related to representing the state of the game board.

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -1,0 +1,48 @@
+import { Board, BOARD_SIZE } from './board';
+
+import { expect, test } from 'vitest';
+
+test(
+  'Board is constructed with a 16x16 array of wall-less cells',
+  () => {
+    let board = new Board();
+    for (let row of board.cells) {
+      for (let cell of row) {
+        expect(cell.walls.length).toBe(0);
+      }
+    }
+  },
+);
+
+test(
+  'Board is constructed with center cells obstructed',
+  () => {
+    let board = new Board();
+
+    let center_cells = [7, 8];
+
+    for (let row = 0; row < BOARD_SIZE; row++) {
+      for (let col = 0; col < BOARD_SIZE; col++) {
+        if (center_cells.includes(row) && center_cells.includes(col)) {
+          expect(board.cells[row][col].isObstructed).toBe(true);
+        } else {
+          expect(board.cells[row][col].isObstructed).toBe(false);
+        }
+      }
+    }
+  },
+);
+
+test(
+  'Board is constructed with four robots on the top row',
+  () => {
+    let board = new Board();
+    expect(board.robots.length).toBe(4);
+    expect(board.robotPositions).toStrictEqual([
+      {row: 0, column: 0},
+      {row: 0, column: 1},
+      {row: 0, column: 2},
+      {row: 0, column: 3},
+    ])
+  },
+);

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -1,0 +1,56 @@
+import { Cell } from './cell';
+import { Color } from './color';
+import { Robot } from './robot';
+
+/*
+ * The height and width of the board
+ */
+export const BOARD_SIZE = 16;
+
+/*
+ * Describes the location of an object on the board
+ */
+type Position = {
+  row: number,
+  column: number,
+};
+
+export class Board {
+  cells: Cell[][] ;
+  robots: Robot[];
+  robotPositions: Position[];
+
+  constructor() {
+    let cells = new Array(BOARD_SIZE)
+
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      let row = new Array(BOARD_SIZE);
+      for (let c = 0; c < BOARD_SIZE; c++) {
+        row[c] = new Cell();
+      }
+      cells[r] = row
+    }
+
+    // The cells in the center of the board
+    // are always obstructed
+    cells[7][7].isObstructed = true;
+    cells[7][8].isObstructed = true;
+    cells[8][7].isObstructed = true;
+    cells[8][8].isObstructed = true;
+
+    this.cells = cells;
+    this.robots = [
+      new Robot(Color.Red),
+      new Robot(Color.Yellow),
+      new Robot(Color.Green),
+      new Robot(Color.Blue),
+    ];
+
+    this.robotPositions = [
+      { row: 0, column: 0},
+      { row: 0, column: 1},
+      { row: 0, column: 2},
+      { row: 0, column: 3},
+    ];
+  }
+}

--- a/frontend/src/board/cell.test.ts
+++ b/frontend/src/board/cell.test.ts
@@ -1,0 +1,45 @@
+import { Cell } from './cell';
+import { Wall } from './wall';
+
+import { expect, test } from 'vitest';
+
+test('Default cell holds expected values', () => {
+  let default_cell = new Cell();
+  expect(default_cell.walls.length).toBe(0);
+  expect(default_cell.isObstructed).toBe(false);
+  expect(default_cell.isTarget).toBe(false);
+});
+
+test('Adding wall updates walls correctly', () => {
+  let cell = new Cell();
+  cell.addWall(Wall.North);
+  expect(cell.walls.length).toBe(1);
+  expect(cell.walls).toStrictEqual([Wall.North]);
+});
+
+test('Adding walls twice works correctly', () => {
+  let cell = new Cell();
+  cell.addWall(Wall.North);
+  cell.addWall(Wall.North);
+  expect(cell.walls.length).toBe(1);
+  expect(cell.walls).toStrictEqual([Wall.North]);
+})
+
+test('Removing walls works correctly', () => {
+  let cell = new Cell();
+  cell.addWall(Wall.North);
+  expect(cell.walls.length).toBe(1);
+  expect(cell.walls).toStrictEqual([Wall.North]);
+  cell.removeWall(Wall.North);
+  expect(cell.walls.length).toEqual(0);
+})
+
+test('Removing nonexistent wall is no-op', () => {
+  let cell = new Cell();
+  cell.addWall(Wall.North);
+  expect(cell.walls.length).toBe(1);
+  expect(cell.walls).toStrictEqual([Wall.North]);
+  cell.removeWall(Wall.South);
+  expect(cell.walls.length).toBe(1);
+  expect(cell.walls).toStrictEqual([Wall.North]);
+})

--- a/frontend/src/board/cell.ts
+++ b/frontend/src/board/cell.ts
@@ -1,0 +1,40 @@
+import { Wall } from './wall';
+
+/**
+ * Encapsulates the state of a cell on the board including:
+ *   - Does it have any walls?
+ *   - Is it one of the center pieces?
+ *   - Is it the current target?
+ */
+export class Cell {
+  public walls: Wall[];
+  public isTarget: boolean;
+  public isObstructed: boolean;
+
+  public constructor() {
+    this.walls = [];
+    this.isTarget = false;
+    this.isObstructed = false;
+  }
+
+  /**
+   * Adds a wall to the cell if it isn't already present
+   * @param wall - The wall to be added to the cell
+   */
+  public addWall(wall: Wall) {
+    if (!this.walls.includes(wall)) {
+      this.walls.push(wall);
+    }
+  }
+
+  /**
+   * Removes a wall from the cell if it is present
+   * @param wall - The wall to be removed from the cell
+   */
+  public removeWall(wall: Wall) {
+    let i = this.walls.indexOf(wall);
+    if (i > -1) {
+      this.walls.splice(i, 1);
+    }
+  }
+}

--- a/frontend/src/board/color.ts
+++ b/frontend/src/board/color.ts
@@ -1,0 +1,9 @@
+/**
+ * Encodes the color of the different robots / cells
+ */
+export enum Color {
+  Red,
+  Green,
+  Blue,
+  Yellow,
+}

--- a/frontend/src/board/robot.ts
+++ b/frontend/src/board/robot.ts
@@ -1,0 +1,11 @@
+import { Color } from './color';
+
+export class Robot {
+  isTarget: boolean;
+  color: Color;
+
+  constructor(color: Color) {
+    this.isTarget = false;
+    this.color = color;
+  }
+}

--- a/frontend/src/board/wall.ts
+++ b/frontend/src/board/wall.ts
@@ -1,0 +1,6 @@
+export enum Wall {
+  North,
+  South,
+  East,
+  West,
+}


### PR DESCRIPTION
This commit adds some types to represent the state of the board.

Currently these are just constructed with some default values, but in a later commit these will be initialized with a builder to make board state initialization simple