### PR TITLE
Feauture/eligible moves

### DIFF
--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -76,11 +76,11 @@ test('Checking eligible move in the West direction', () => {
 
 test("Should return target cell in path", () => {
   let board = new Board();
-  if (board.cells[15] && board.cells[15][15]) {
-    board.cells[15][15].isObstructed = true;
+  if (board.cells[15] && board.cells[15][14]) {
+    board.cells[15][14].isTarget = true;
   }
-  expect(board.checkDirections(9,15,"South")).toStrictEqual({row:15,column:15})
-  expect(board.checkDirections(15,9,"East")).toStrictEqual({row:15,column:15})
+  expect(board.checkDirections(9,14,"South")).toStrictEqual({row:15,column:14})
+  expect(board.checkDirections(15,9,"East")).toStrictEqual({row:15,column:14})
 })
 
 test("Checking eligible move position if another robot is in the path", () => {
@@ -94,6 +94,12 @@ test("Checking eligible move position if another robot is in the path", () => {
   expect(board.checkDirections(0, 0, 'East')).toStrictEqual(null)
   expect(board.checkDirections(0, 0, 'South')).toStrictEqual({ row: 10, column: 0 })
 })
+
+// test("Checking elgible move does not return an isObstructed cell position", () => {
+//   let board = new Board();
+//   expect(board.checkDirections(0,8,'South')).toStrictEqual({row: 6, column: 8})
+
+// } )
 
 
 

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -67,12 +67,23 @@ test('Checking eligible moves in the East direction', () => {
     {row: 6, column: 15})
 }
 )
-test('Checking eligible moves in the West direction', () => {
+test('Checking eligible move in the West direction', () => {
   let board = new Board();
   expect(board.checkDirections(6, 15, 'West')).toStrictEqual(
   {row: 6, column: 0})
 }
 )
+
+test("Should return target cell in path", () => {
+  let board = new Board();
+  if (board.cells[15] && board.cells[15][15]) {
+    board.cells[15][15].isObstructed = true;
+  }
+  expect(board.checkDirections(9,15,"South")).toStrictEqual({row:15,column:15})
+  expect(board.checkDirections(15,9,"East")).toStrictEqual({row:15,column:15})
+})
+
+
 
 
 

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -51,89 +51,84 @@ test(
 
 test('Checking eligible moves in the North direction', () => {
   let board = new Board();
-  expect(board.checkDirections(6, 15, 'North')).toStrictEqual(
-    { row: 0, column: 15 })
-}
-)
+  expect(board.checkDirections({ row: 6, column: 15 }, Direction.North)).toStrictEqual(
+    { row: 0, column: 15 }
+  );
+});
+
 test('Checking eligible moves in the South direction', () => {
   let board = new Board();
-  expect(board.checkDirections(6, 15, 'South')).toStrictEqual(
-    { row: 15, column: 15 })
-}
-)
+  expect(board.checkDirections({ row: 6, column: 15 }, Direction.South)).toStrictEqual(
+    { row: 15, column: 15 }
+  );
+});
 
 test('Checking eligible moves in the East direction', () => {
   let board = new Board();
-  expect(board.checkDirections(6, 14, 'East')).toStrictEqual(
-    {row: 6, column: 15})
-}
-)
+  expect(board.checkDirections({ row: 6, column: 14 }, Direction.East)).toStrictEqual(
+    { row: 6, column: 15 }
+  );
+});
+
 test('Checking eligible move in the West direction', () => {
   let board = new Board();
-  expect(board.checkDirections(6, 15, 'West')).toStrictEqual(
-  {row: 6, column: 0})
-}
-)
+  expect(board.checkDirections({ row: 6, column: 15 }, Direction.West)).toStrictEqual(
+    { row: 6, column: 0 }
+  );
+});
 
 test("Should return target cell in path", () => {
   let board = new Board();
   if (board.cells[15] && board.cells[15][14]) {
     board.cells[15][14].isTarget = true;
   }
-  expect(board.checkDirections(9,14,"South")).toStrictEqual({row:15,column:14})
-  expect(board.checkDirections(15,9,"East")).toStrictEqual({row:15,column:14})
-})
+  expect(board.checkDirections({ row: 9, column: 14 }, Direction.South)).toStrictEqual({ row: 15, column: 14 });
+  expect(board.checkDirections({ row: 15, column: 9 }, Direction.East)).toStrictEqual({ row: 15, column: 14 });
+});
 
 test("Checking eligible move position if another robot is in the path", () => {
   let board = new Board();
   board.robotPositions = [
-    { row: 0, column: 0},
-    { row: 0, column: 1},
-    { row: 11, column: 0},
-    { row: 0, column: 3},
+    { row: 0, column: 0 },
+    { row: 0, column: 1 },
+    { row: 11, column: 0 },
+    { row: 0, column: 3 },
   ];
-  expect(board.checkDirections(0, 0, 'East')).toStrictEqual(null)
-  expect(board.checkDirections(0, 0, 'South')).toStrictEqual({ row: 10, column: 0 })
-})
+  expect(board.checkDirections({ row: 0, column: 0 }, Direction.East)).toStrictEqual(null);
+  expect(board.checkDirections({ row: 0, column: 0 }, Direction.South)).toStrictEqual({ row: 10, column: 0 });
+});
 
 test("Checking eligibleMove method does not return an isObstructed cell position", () => {
   let board = new Board();
   // from South
-  expect(board.checkDirections(0, 8, 'South')).toStrictEqual({ row: 6, column: 8  })
-  expect(board.checkDirections(3, 7, 'South')).toStrictEqual({ row: 6, column: 7 })
+  expect(board.checkDirections({ row: 0, column: 8 }, Direction.South)).toStrictEqual({ row: 6, column: 8 });
+  expect(board.checkDirections({ row: 3, column: 7 }, Direction.South)).toStrictEqual({ row: 6, column: 7 });
   // from North
-  expect(board.checkDirections(15, 7, 'North')).toStrictEqual({ row: 9, column: 7 })
-  expect(board.checkDirections(15, 8, 'North')).toStrictEqual({ row: 9, column: 8 })
+  expect(board.checkDirections({ row: 15, column: 7 }, Direction.North)).toStrictEqual({ row: 9, column: 7 });
+  expect(board.checkDirections({ row: 15, column: 8 }, Direction.North)).toStrictEqual({ row: 9, column: 8 });
   // from East
-  expect(board.checkDirections(7, 0, 'East')).toStrictEqual({ row: 7, column: 6 })
-  expect(board.checkDirections(8, 4, 'East')).toStrictEqual({ row: 8, column: 6 })
+  expect(board.checkDirections({ row: 7, column: 0 }, Direction.East)).toStrictEqual({ row: 7, column: 6 });
+  expect(board.checkDirections({ row: 8, column: 4 }, Direction.East)).toStrictEqual({ row: 8, column: 6 });
   // from West
-  expect(board.checkDirections(7, 10, 'West')).toStrictEqual({ row: 7, column: 9 })
-  expect(board.checkDirections(8, 13, 'West')).toStrictEqual({ row: 8, column: 9 })
-} )
+  expect(board.checkDirections({ row: 7, column: 10 }, Direction.West)).toStrictEqual({ row: 7, column: 9 });
+  expect(board.checkDirections({ row: 8, column: 13 }, Direction.West)).toStrictEqual({ row: 8, column: 9 });
+});
 
 test("Checking eligibleMove method handles walls correctly", () => {
-  let board = new Board()
-  board.cells[1]?.[1]?.addWall(Direction.West)
-  board.cells[1]?.[1]?.addWall(Direction.South)
-  board.cells[1]?.[0]?.addWall(Direction.East)
-  board.cells[2]?.[1]?.addWall(Direction.North)
+  let board = new Board();
+  board.cells[1]?.[1]?.addWall(Direction.West);
+  board.cells[1]?.[1]?.addWall(Direction.South);
+  board.cells[1]?.[0]?.addWall(Direction.East);
+  board.cells[2]?.[1]?.addWall(Direction.North);
   // if robot already at a cell with a wall
-  expect(board.checkDirections(2, 1, 'North')).toStrictEqual(null)
-  expect(board.checkDirections(1, 0, 'East')).toStrictEqual(null)
-  expect(board.checkDirections(1, 1, 'West')).toStrictEqual(null)
-  expect(board.checkDirections(1, 1, 'South')).toStrictEqual(null)
-  expect(board.checkDirections(1, 1, 'East')).toStrictEqual({row:1, column: 15})
+  expect(board.checkDirections({ row: 2, column: 1 }, Direction.North)).toStrictEqual(null);
+  expect(board.checkDirections({ row: 1, column: 0 }, Direction.East)).toStrictEqual(null);
+  expect(board.checkDirections({ row: 1, column: 1 }, Direction.West)).toStrictEqual(null);
+  expect(board.checkDirections({ row: 1, column: 1 }, Direction.South)).toStrictEqual(null);
+  expect(board.checkDirections({ row: 1, column: 1 }, Direction.East)).toStrictEqual({ row: 1, column: 15 });
 
-
-  expect(board.checkDirections(5, 1, 'North')).toStrictEqual({row:2, column: 1})
-  expect(board.checkDirections(1, 2, 'West')).toStrictEqual({ row: 1, column: 1 })
-  expect(board.checkDirections(1, 8, 'West')).toStrictEqual({ row: 1, column: 1 })
-  expect(board.checkDirections(0, 1, 'South')).toStrictEqual({ row: 1, column: 1 })
- 
-
-})
-
-
-
-
+  expect(board.checkDirections({ row: 5, column: 1 }, Direction.North)).toStrictEqual({ row: 2, column: 1 });
+  expect(board.checkDirections({ row: 1, column: 2 }, Direction.West)).toStrictEqual({ row: 1, column: 1 });
+  expect(board.checkDirections({ row: 1, column: 8 }, Direction.West)).toStrictEqual({ row: 1, column: 1 });
+  expect(board.checkDirections({ row: 0, column: 1 }, Direction.South)).toStrictEqual({ row: 1, column: 1 });
+});

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -95,11 +95,23 @@ test("Checking eligible move position if another robot is in the path", () => {
   expect(board.checkDirections(0, 0, 'South')).toStrictEqual({ row: 10, column: 0 })
 })
 
-// test("Checking elgible move does not return an isObstructed cell position", () => {
-//   let board = new Board();
-//   expect(board.checkDirections(0,8,'South')).toStrictEqual({row: 6, column: 8})
-
-// } )
+test("Checking elgible move does not return an isObstructed cell position", () => {
+  let board = new Board();
+  // from South
+  expect(board.checkDirections(0, 8, 'South')).toStrictEqual({ row: 6, column: 8  })
+  expect(board.checkDirections(3, 7, 'South')).toStrictEqual({ row: 6, column: 7 })
+  // from North
+  expect(board.checkDirections(15, 7, 'North')).toStrictEqual({ row: 9, column: 7 })
+  expect(board.checkDirections(15, 8, 'North')).toStrictEqual({ row: 9, column: 8 })
+  // from East
+  expect(board.checkDirections(7, 0, 'East')).toStrictEqual({ row: 7, column: 6 })
+  expect(board.checkDirections(8, 4, 'East')).toStrictEqual({ row: 8, column: 6 })
+  // from West
+  expect(board.checkDirections(7, 10, 'West')).toStrictEqual({ row: 7, column: 9 })
+  expect(board.checkDirections(8, 13, 'West')).toStrictEqual({ row: 8, column: 9 })
+  
+  
+} )
 
 
 

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -83,6 +83,18 @@ test("Should return target cell in path", () => {
   expect(board.checkDirections(15,9,"East")).toStrictEqual({row:15,column:15})
 })
 
+test("Checking eligible move position if another robot is in the path", () => {
+  let board = new Board();
+  board.robotPositions = [
+    { row: 0, column: 0},
+    { row: 0, column: 1},
+    { row: 11, column: 0},
+    { row: 0, column: 3},
+  ];
+  expect(board.checkDirections(0, 0, 'East')).toStrictEqual(null)
+  expect(board.checkDirections(0, 0, 'South')).toStrictEqual({ row: 10, column: 0 })
+})
+
 
 
 

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -46,3 +46,13 @@ test(
     ])
   },
 );
+
+
+test('Checking eligible moves in the North direction', () => {
+  let board = new Board();
+  expect(board.checkDirections(6, 15, 'North')).toStrictEqual(
+    { row: 0, column: 15 })
+}
+)
+
+

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -79,13 +79,10 @@ test('Checking eligible move in the West direction', () => {
 
 test("Should return target cell in path", () => {
   let board = new Board();
-  if (board.cells[15] && board.cells[15][14]) {
-    board.cells[15][14].isTarget = true;
-  }
+  board.cells[15]![14]!.isTarget = true;
   expect(board.checkDirections({ row: 9, column: 14 }, Direction.South)).toStrictEqual({ row: 15, column: 14 });
   expect(board.checkDirections({ row: 15, column: 9 }, Direction.East)).toStrictEqual({ row: 15, column: 14 });
 });
-
 test("Checking eligible move position if another robot is in the path", () => {
   let board = new Board();
   board.robotPositions = [

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -54,5 +54,25 @@ test('Checking eligible moves in the North direction', () => {
     { row: 0, column: 15 })
 }
 )
+test('Checking eligible moves in the South direction', () => {
+  let board = new Board();
+  expect(board.checkDirections(6, 15, 'South')).toStrictEqual(
+    { row: 15, column: 15 })
+}
+)
+
+test('Checking eligible moves in the East direction', () => {
+  let board = new Board();
+  expect(board.checkDirections(6, 14, 'East')).toStrictEqual(
+    {row: 6, column: 15})
+}
+)
+test('Checking eligible moves in the West direction', () => {
+  let board = new Board();
+  expect(board.checkDirections(6, 15, 'West')).toStrictEqual(
+  {row: 6, column: 0})
+}
+)
+
 
 

--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -1,6 +1,7 @@
 import { Board, BOARD_SIZE } from './board';
 
 import { expect, test } from 'vitest';
+import { Direction } from './direction';
 
 test(
   'Board is constructed with a 16x16 array of wall-less cells',
@@ -95,7 +96,7 @@ test("Checking eligible move position if another robot is in the path", () => {
   expect(board.checkDirections(0, 0, 'South')).toStrictEqual({ row: 10, column: 0 })
 })
 
-test("Checking elgible move does not return an isObstructed cell position", () => {
+test("Checking eligibleMove method does not return an isObstructed cell position", () => {
   let board = new Board();
   // from South
   expect(board.checkDirections(0, 8, 'South')).toStrictEqual({ row: 6, column: 8  })
@@ -109,10 +110,29 @@ test("Checking elgible move does not return an isObstructed cell position", () =
   // from West
   expect(board.checkDirections(7, 10, 'West')).toStrictEqual({ row: 7, column: 9 })
   expect(board.checkDirections(8, 13, 'West')).toStrictEqual({ row: 8, column: 9 })
-  
-  
 } )
 
+test("Checking eligibleMove method handles walls correctly", () => {
+  let board = new Board()
+  board.cells[1]?.[1]?.addWall(Direction.West)
+  board.cells[1]?.[1]?.addWall(Direction.South)
+  board.cells[1]?.[0]?.addWall(Direction.East)
+  board.cells[2]?.[1]?.addWall(Direction.North)
+  // if robot already at a cell with a wall
+  expect(board.checkDirections(2, 1, 'North')).toStrictEqual(null)
+  expect(board.checkDirections(1, 0, 'East')).toStrictEqual(null)
+  expect(board.checkDirections(1, 1, 'West')).toStrictEqual(null)
+  expect(board.checkDirections(1, 1, 'South')).toStrictEqual(null)
+  expect(board.checkDirections(1, 1, 'East')).toStrictEqual({row:1, column: 15})
+
+
+  expect(board.checkDirections(5, 1, 'North')).toStrictEqual({row:2, column: 1})
+  expect(board.checkDirections(1, 2, 'West')).toStrictEqual({ row: 1, column: 1 })
+  expect(board.checkDirections(1, 8, 'West')).toStrictEqual({ row: 1, column: 1 })
+  expect(board.checkDirections(0, 1, 'South')).toStrictEqual({ row: 1, column: 1 })
+ 
+
+})
 
 
 

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -100,9 +100,9 @@ export class Board {
 
       
       // check if obstructed
-      // if (this.cells[row]?.[col]?.isObstructed) {
-      //   break
-      // }
+      if (this.cells[row]?.[col]?.isObstructed) {
+        break
+      }
       // check if wall exists
       // if (this.cells[row]?.[col]?.walls?.length! > 0) {
       //   this.cells[row]?.[col]?.walls.forEach(wall => {

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -75,10 +75,11 @@ export class Board {
     while (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE) {
 
       // check if target, add position
-      // if (this.cells[row]?.[col]?.isTarget) {
-      //   this.eligibleMoves[direction].push({ row: row, column: col })
-      //   break
-      // }
+
+      if (this.cells[row]?.[col]?.isTarget) {
+        legalMove = {row: row, column: col}
+        break
+      }
 
       // let robotEncountered = false 
       // // robots 

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -72,7 +72,7 @@ export class Board {
     let col = startPos.column
  
     while (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE) {
-
+     
       // check if target, add position
 
       let robotEncountered = false 
@@ -91,13 +91,11 @@ export class Board {
         break; 
       }
 
-
       if (this.cells[row]?.[col]?.isTarget) {
         legalMove = {row: row, column: col}
         break
       }
 
-      
       // check if obstructed
       if (this.cells[row]?.[col]?.isObstructed) {
         break
@@ -118,32 +116,26 @@ export class Board {
             if (!(row === startPos.row && col === startPos.column))
             legalMove = {row: row, column:col}
           } 
-          
-    
         })
       }
       if (wallPreventsEntrance) {
-        
         break
       }
-  
-      
       if (!(row === startPos.row && col === startPos.column)) {
         legalMove = {row: row, column: col}
       }
-
-      if (Direction.North) {
+ 
+      if (direction === Direction.North) {
         row--;
-      } else if (Direction.South) {
+      } else if (direction === Direction.South) {
         row++;
-      } else if (Direction.East) {
+      } else if (direction === Direction.East) {
         col++;
-      } else if (Direction.West) {
+      } else if (direction === Direction.West) {
         col--;
       }
-    
     }
+
     return legalMove 
-    
   }
 }

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -76,26 +76,29 @@ export class Board {
 
       // check if target, add position
 
+      let robotEncountered = false 
+      // robots 
+      this.robotPositions.forEach(robot => {
+        // designated robot does not check its own position
+        if (robot.row === startRow && robot.column === startCol) {
+          return 
+        }
+        if (row === robot.row && col === robot.column) {
+          robotEncountered = true 
+        }
+      })
+
+      if (robotEncountered) {
+        break; 
+      }
+
+
       if (this.cells[row]?.[col]?.isTarget) {
         legalMove = {row: row, column: col}
         break
       }
 
-      // let robotEncountered = false 
-      // // robots 
-      // this.robotPositions.forEach(robot => {
-      //   if (robot.row == startRow && robot.column == startCol) {
-      //     return 
-      //   }
-      //   if (row === robot.row && col === robot.column) {
-      //     robotEncountered = true 
-      //   }
-      // })
-
-      // if (robotEncountered) {
-      //   break; 
-      // }
-
+      
       // check if obstructed
       // if (this.cells[row]?.[col]?.isObstructed) {
       //   break

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -2,6 +2,7 @@ import { Cell } from './cell';
 import { Color } from './color';
 import { Robot } from './robot';
 import type { Position } from './position';
+import { Direction } from './direction';
 // import { Direction } from './direction'
 
 /*
@@ -103,20 +104,30 @@ export class Board {
       if (this.cells[row]?.[col]?.isObstructed) {
         break
       }
+
+      let wallPreventsEntrance = false 
       // check if wall exists
-      // if (this.cells[row]?.[col]?.walls?.length! > 0) {
-      //   this.cells[row]?.[col]?.walls.forEach(wall => {
-      //     // Add position if the cell does NOT contain a wall
-      //     if ((direction === 'North' && wall !== Wall.South) || 
-      //       (direction === 'South' && wall !== Wall.North) ||
-      //       (direction === 'East' && wall !== Wall.West) ||
-      //       (direction === 'West' && wall !== Wall.East)) {
-      //       this.eligibleMoves[direction].push({ row: row, column: col })
-      //     }
+      if (this.cells[row]?.[col]?.walls?.length! > 0) {
+  
+        this.cells[row]?.[col]?.walls.forEach(wall => {
+          // Wall prevents entrance into next cell
+          if ((direction === 'North' && wall === Direction.North) || 
+            (direction === 'South' && wall === Direction.South) ||
+            (direction === 'East' && wall === Direction.East) ||
+            (direction === 'West' && wall === Direction.West)) {
+            wallPreventsEntrance = true
+
+            if (!(row === startRow && col === startCol))
+            legalMove = {row: row, column:col}
+          } 
           
-      //   })
-      //   break
-      // }
+    
+        })
+      }
+      if (wallPreventsEntrance) {
+        
+        break
+      }
   
       
       if (!(row === startRow && col === startCol)) {

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -52,14 +52,14 @@ export class Board {
 
   findMoves() {
     return {
-      north: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'North'),
-    south: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'South'),
-    east: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'East'),
-    west: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'West')
+      north: this.checkDirections(this.robotPositions[0], Direction.North),
+      south: this.checkDirections(this.robotPositions[0], Direction.South),
+      east: this.checkDirections(this.robotPositions[0], Direction.East),
+      west: this.checkDirections(this.robotPositions[0], Direction.West)
     }
   }
 
-  checkDirections(startRow:number, startCol: number, direction: 'North' | 'South' | 'East' | 'West' ) : null | Position {
+  checkDirections(startPos: Position, direction: Direction) : null | Position {
     // Gets the position of the target robot
     // Checks the north, south, east, and west path
     // Path ends if
@@ -68,10 +68,8 @@ export class Board {
     // - or the cell is the target cell
 
     let legalMove: Position | null = null 
-    
-    
-    let row = startRow
-    let col = startCol
+    let row = startPos.row
+    let col = startPos.column
  
     while (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE) {
 
@@ -81,7 +79,7 @@ export class Board {
       // robots 
       this.robotPositions.forEach(robot => {
         // designated robot does not check its own position
-        if (robot.row === startRow && robot.column === startCol) {
+        if (robot.row === startPos.row && robot.column === startPos.column) {
           return 
         }
         if (row === robot.row && col === robot.column) {
@@ -111,13 +109,13 @@ export class Board {
   
         this.cells[row]?.[col]?.walls.forEach(wall => {
           // Wall prevents entrance into next cell
-          if ((direction === 'North' && wall === Direction.North) || 
-            (direction === 'South' && wall === Direction.South) ||
-            (direction === 'East' && wall === Direction.East) ||
-            (direction === 'West' && wall === Direction.West)) {
+          if ((direction === Direction.North && wall === Direction.North) || 
+            (direction === Direction.South && wall === Direction.South) ||
+            (direction === Direction.East && wall === Direction.East) ||
+            (direction === Direction.West && wall === Direction.West)) {
             wallPreventsEntrance = true
 
-            if (!(row === startRow && col === startCol))
+            if (!(row === startPos.row && col === startPos.column))
             legalMove = {row: row, column:col}
           } 
           
@@ -130,17 +128,17 @@ export class Board {
       }
   
       
-      if (!(row === startRow && col === startCol)) {
+      if (!(row === startPos.row && col === startPos.column)) {
         legalMove = {row: row, column: col}
       }
 
-      if (direction === 'North') {
+      if (Direction.North) {
         row--;
-      } else if (direction === 'South') {
+      } else if (Direction.South) {
         row++;
-      } else if (direction === 'East') {
+      } else if (Direction.East) {
         col++;
-      } else if (direction === 'West') {
+      } else if (Direction.West) {
         col--;
       }
     

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -65,7 +65,7 @@ export class Board {
     // Path ends if
     // - it is the last cell in the direction
     // - or the cell is obstructed with either another robot, a wall, or the center pieces
-    // - or the cell is the target cell
+    
 
     let legalMove: Position | null = null 
     let row = startPos.row
@@ -89,11 +89,6 @@ export class Board {
 
       if (robotEncountered) {
         break; 
-      }
-
-      if (this.cells[row]?.[col]?.isTarget) {
-        legalMove = {row: row, column: col}
-        break
       }
 
       // check if obstructed

--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -2,6 +2,7 @@ import { Cell } from './cell';
 import { Color } from './color';
 import { Robot } from './robot';
 import type { Position } from './position';
+// import { Direction } from './direction'
 
 /*
  * The height and width of the board
@@ -45,5 +46,91 @@ export class Board {
       { row: 0, column: 2},
       { row: 0, column: 3},
     ];
+
+  }
+
+  findMoves() {
+    return {
+      north: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'North'),
+    south: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'South'),
+    east: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'East'),
+    west: this.checkDirections(this.robotPositions[0].row, this.robotPositions[0].column, 'West')
+    }
+  }
+
+  checkDirections(startRow:number, startCol: number, direction: 'North' | 'South' | 'East' | 'West' ) : null | Position {
+    // Gets the position of the target robot
+    // Checks the north, south, east, and west path
+    // Path ends if
+    // - it is the last cell in the direction
+    // - or the cell is obstructed with either another robot, a wall, or the center pieces
+    // - or the cell is the target cell
+
+    let legalMove: Position | null = null 
+    
+    
+    let row = startRow
+    let col = startCol
+ 
+    while (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE) {
+
+      // check if target, add position
+      // if (this.cells[row]?.[col]?.isTarget) {
+      //   this.eligibleMoves[direction].push({ row: row, column: col })
+      //   break
+      // }
+
+      // let robotEncountered = false 
+      // // robots 
+      // this.robotPositions.forEach(robot => {
+      //   if (robot.row == startRow && robot.column == startCol) {
+      //     return 
+      //   }
+      //   if (row === robot.row && col === robot.column) {
+      //     robotEncountered = true 
+      //   }
+      // })
+
+      // if (robotEncountered) {
+      //   break; 
+      // }
+
+      // check if obstructed
+      // if (this.cells[row]?.[col]?.isObstructed) {
+      //   break
+      // }
+      // check if wall exists
+      // if (this.cells[row]?.[col]?.walls?.length! > 0) {
+      //   this.cells[row]?.[col]?.walls.forEach(wall => {
+      //     // Add position if the cell does NOT contain a wall
+      //     if ((direction === 'North' && wall !== Wall.South) || 
+      //       (direction === 'South' && wall !== Wall.North) ||
+      //       (direction === 'East' && wall !== Wall.West) ||
+      //       (direction === 'West' && wall !== Wall.East)) {
+      //       this.eligibleMoves[direction].push({ row: row, column: col })
+      //     }
+          
+      //   })
+      //   break
+      // }
+  
+      
+      if (!(row === startRow && col === startCol)) {
+        legalMove = {row: row, column: col}
+      }
+
+      if (direction === 'North') {
+        row--;
+      } else if (direction === 'South') {
+        row++;
+      } else if (direction === 'East') {
+        col++;
+      } else if (direction === 'West') {
+        col--;
+      }
+    
+    }
+    return legalMove 
+    
   }
 }

--- a/frontend/src/board/cell.test.ts
+++ b/frontend/src/board/cell.test.ts
@@ -1,5 +1,5 @@
 import { Cell } from './cell';
-import { Wall } from './wall';
+import { Direction } from './direction';
 
 import { expect, test } from 'vitest';
 
@@ -12,34 +12,34 @@ test('Default cell holds expected values', () => {
 
 test('Adding wall updates walls correctly', () => {
   let cell = new Cell();
-  cell.addWall(Wall.North);
+  cell.addWall(Direction.North);
   expect(cell.walls.length).toBe(1);
-  expect(cell.walls).toStrictEqual([Wall.North]);
+  expect(cell.walls).toStrictEqual([Direction.North]);
 });
 
 test('Adding walls twice works correctly', () => {
   let cell = new Cell();
-  cell.addWall(Wall.North);
-  cell.addWall(Wall.North);
+  cell.addWall(Direction.North);
+  cell.addWall(Direction.North);
   expect(cell.walls.length).toBe(1);
-  expect(cell.walls).toStrictEqual([Wall.North]);
+  expect(cell.walls).toStrictEqual([Direction.North]);
 })
 
 test('Removing walls works correctly', () => {
   let cell = new Cell();
-  cell.addWall(Wall.North);
+  cell.addWall(Direction.North);
   expect(cell.walls.length).toBe(1);
-  expect(cell.walls).toStrictEqual([Wall.North]);
-  cell.removeWall(Wall.North);
+  expect(cell.walls).toStrictEqual([Direction.North]);
+  cell.removeWall(Direction.North);
   expect(cell.walls.length).toEqual(0);
 })
 
 test('Removing nonexistent wall is no-op', () => {
   let cell = new Cell();
-  cell.addWall(Wall.North);
+  cell.addWall(Direction.North);
   expect(cell.walls.length).toBe(1);
-  expect(cell.walls).toStrictEqual([Wall.North]);
-  cell.removeWall(Wall.South);
+  expect(cell.walls).toStrictEqual([Direction.North]);
+  cell.removeWall(Direction.South);
   expect(cell.walls.length).toBe(1);
-  expect(cell.walls).toStrictEqual([Wall.North]);
+  expect(cell.walls).toStrictEqual([Direction.North]);
 })

--- a/frontend/src/board/cell.ts
+++ b/frontend/src/board/cell.ts
@@ -1,4 +1,4 @@
-import { Wall } from './wall';
+import { Direction } from './direction';
 
 /**
  * Encapsulates the state of a cell on the board including:
@@ -7,7 +7,7 @@ import { Wall } from './wall';
  *   - Is it the current target?
  */
 export class Cell {
-  public walls: Wall[];
+  public walls: Direction[];
   public isTarget: boolean;
   public isObstructed: boolean;
 
@@ -21,7 +21,7 @@ export class Cell {
    * Adds a wall to the cell if it isn't already present
    * @param wall - The wall to be added to the cell
    */
-  public addWall(wall: Wall) {
+  public addWall(wall: Direction) {
     if (!this.walls.includes(wall)) {
       this.walls.push(wall);
     }
@@ -31,7 +31,7 @@ export class Cell {
    * Removes a wall from the cell if it is present
    * @param wall - The wall to be removed from the cell
    */
-  public removeWall(wall: Wall) {
+  public removeWall(wall: Direction) {
     let i = this.walls.indexOf(wall);
     if (i > -1) {
       this.walls.splice(i, 1);

--- a/frontend/src/board/direction.ts
+++ b/frontend/src/board/direction.ts
@@ -1,4 +1,4 @@
-export enum Wall {
+export enum Direction {
   North,
   South,
   East,

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,16 +1,19 @@
 
 import javascriptLogo from '/assets/javascript.svg'
 import viteLogo from '/assets/vite.svg'
-import { setupCounter } from './counter.js'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 
 import Positions from './positions.js'
-import { placeWalls, onMouseDown,onMouseMove} from './utilites.js'
+import { placeWalls, onMouseDown, onMouseMove } from './utilites.js'
+import { BoardBuilder } from './util/boardBuilder.ts'
 import * as THREE from 'three'
 
-
-const boardPositions = new Positions
-
+const boardBuilder = new BoardBuilder()
+console.log(boardBuilder)
+const boardPos = boardBuilder.build()
+console.log(boardPos)
+const boardPositions = new Positions()
+console.log(boardPositions)
 const canvas = document.querySelector('canvas.webgl')
 
 // symbol texture loader 

--- a/frontend/src/util/boardBuilder.test.ts
+++ b/frontend/src/util/boardBuilder.test.ts
@@ -3,7 +3,7 @@ import { BoardBuilder } from './boardBuilder'
 import { Board } from '../board/board';
 import { Color } from '../board/color';
 import { Robot } from '../board/robot';
-import { Wall } from '../board/wall';
+import { Direction } from '../board/direction';
 
 test(
   'Empty builder returns default board',
@@ -35,13 +35,13 @@ test(
   'Builder adds walls appropriately',
   () => {
     let board = new BoardBuilder()
-      .withWall(Wall.North,{ row: 1, column: 0 })
-      .withWall(Wall.East, { row: 1, column: 0 })
+      .withWall(Direction.North,{ row: 1, column: 0 })
+      .withWall(Direction.East, { row: 1, column: 0 })
       .build();
 
-    expect(board.cells[1]?.[0]?.walls).toStrictEqual([Wall.North, Wall.East]);
-    expect(board.cells[0]?.[0]?.walls).toStrictEqual([Wall.South]);
-    expect(board.cells[1]?.[1]?.walls).toStrictEqual([Wall.West]);
+    expect(board.cells[1]?.[0]?.walls).toStrictEqual([Direction.North, Direction.East]);
+    expect(board.cells[0]?.[0]?.walls).toStrictEqual([Direction.South]);
+    expect(board.cells[1]?.[1]?.walls).toStrictEqual([Direction.West]);
   }
 )
 
@@ -49,13 +49,13 @@ test(
   "Builder doesn't crash when border walls are added",
   () => {
     let board = new BoardBuilder()
-      .withWall(Wall.North, { row: 0, column: 0 })
-      .withWall(Wall.West, { row: 0, column: 0 })
-      .withWall(Wall.East, { row: 15, column: 15 })
-      .withWall(Wall.South, { row: 15, column: 15 })
+      .withWall(Direction.North, { row: 0, column: 0 })
+      .withWall(Direction.West, { row: 0, column: 0 })
+      .withWall(Direction.East, { row: 15, column: 15 })
+      .withWall(Direction.South, { row: 15, column: 15 })
       .build();
 
-    expect(board.cells[0]?.[0]?.walls).toStrictEqual([Wall.North, Wall.West]);
-    expect(board.cells[15]?.[15]?.walls).toStrictEqual([Wall.East, Wall.South]);
+    expect(board.cells[0]?.[0]?.walls).toStrictEqual([Direction.North, Direction.West]);
+    expect(board.cells[15]?.[15]?.walls).toStrictEqual([Direction.East, Direction.South]);
   }
 )

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -1,12 +1,12 @@
 import { Board } from '../board/board';
 import { Robot } from '../board/robot';
-import { Wall } from '../board/wall';
+import { Direction } from '../board/direction';
  
 import type { Position } from '../board/position';
 
 export class BoardBuilder {
   robots: [Robot, Position][];
-  walls: [Wall, Position][];
+  walls: [Direction, Position][];
 
   constructor() {
     this.robots = []
@@ -26,7 +26,7 @@ export class BoardBuilder {
     return this;
   }
 
-  public withWall(newWall: Wall, newPosition: Position): BoardBuilder {
+  public withWall(newWall: Direction, newPosition: Position): BoardBuilder {
     let wallPosition = this.walls.find(
       ([oldWall, oldPosition]) => oldWall === newWall &&  oldPosition === newPosition,
     );
@@ -43,17 +43,17 @@ export class BoardBuilder {
       board.cells[row]?.[column]?.addWall(wall);
 
       switch(wall) {
-        case Wall.North:
-          board.cells[row - 1]?.[column]?.addWall(Wall.South);
+        case Direction.North:
+          board.cells[row - 1]?.[column]?.addWall(Direction.South);
           break;
-        case Wall.South:
-          board.cells[row + 1]?.[column]?.addWall(Wall.North);
+        case Direction.South:
+          board.cells[row + 1]?.[column]?.addWall(Direction.North);
           break;
-        case Wall.East:
-          board.cells[row]?.[column + 1]?.addWall(Wall.West);
+        case Direction.East:
+          board.cells[row]?.[column + 1]?.addWall(Direction.West);
           break;
-        case Wall.West:
-          board.cells[row]?.[column - 1]?.addWall(Wall.East);
+        case Direction.West:
+          board.cells[row]?.[column - 1]?.addWall(Direction.East);
           break;
       }
     }


### PR DESCRIPTION
Added logic to eligibleMoves method to find allowed positions a robot is allowed to move into given a direction. The method returns a position based on board size, if a cell is obstructed, if another robot is encountered, and if a wall obstructs an exit from a cell. 

 