### PR TITLE
 Randomly generated and evenly distributed wall positions

### DIFF
--- a/frontend/src/board/board.test.ts
+++ b/frontend/src/board/board.test.ts
@@ -77,12 +77,6 @@ test('Checking eligible move in the West direction', () => {
   );
 });
 
-test("Should return target cell in path", () => {
-  let board = new Board();
-  board.cells[15]![14]!.isTarget = true;
-  expect(board.checkDirections({ row: 9, column: 14 }, Direction.South)).toStrictEqual({ row: 15, column: 14 });
-  expect(board.checkDirections({ row: 15, column: 9 }, Direction.East)).toStrictEqual({ row: 15, column: 14 });
-});
 test("Checking eligible move position if another robot is in the path", () => {
   let board = new Board();
   board.robotPositions = [

--- a/frontend/src/util/boardBuilder.test.ts
+++ b/frontend/src/util/boardBuilder.test.ts
@@ -59,3 +59,60 @@ test(
     expect(board.cells[15]?.[15]?.walls).toStrictEqual([Direction.East, Direction.South]);
   }
 )
+
+test('returns the original and adacent wall position for a given direction', () => {
+  let board = new BoardBuilder()
+  const northDirection = board.wallPositionsToCheck(Direction.North, { row: 2, column: 3 });
+  expect(northDirection).toEqual([
+    [Direction.North, { row: 2, column: 3 }],
+    [Direction.South, { row: 1, column: 3 }]
+  ]);
+
+
+  const southDirection = board.wallPositionsToCheck(Direction.South, { row: 2, column: 3 });
+  expect(southDirection).toEqual([
+    [Direction.South, { row: 2, column: 3 }],
+    [Direction.North, { row: 3, column: 3 }]
+  ]);
+
+  const eastDirection = board.wallPositionsToCheck(Direction.East, { row: 2, column: 3 });
+  expect(eastDirection).toEqual([
+    [Direction.East, { row: 2, column: 3 }],
+    [Direction.West, { row: 2, column: 4 }]
+  ]);
+
+  const westDirection = board.wallPositionsToCheck(Direction.West, { row: 2, column: 3 });
+  expect(westDirection).toEqual([
+    [Direction.West, { row: 2, column: 3 }],
+    [Direction.East, { row: 2, column: 2 }]
+  ]);
+});
+
+test('correctly identifies duplicate walls', () => {
+  let board = new BoardBuilder()
+
+  board.walls =  [
+    [Direction.North, { row: 3, column: 3 }],
+    [Direction.West, { row: 5, column: 5 }]
+  ];
+  
+  const wallsToCheck = board.wallPositionsToCheck(Direction.North, { row: 3, column: 3 });
+  const isDuplicate = board.duplicateWall(wallsToCheck);
+  expect(isDuplicate).toBe(true);
+
+  const downCellsouthWall = board.wallPositionsToCheck(Direction.South, { row: 2, column: 3 });
+  const correspondingSouthWallCheck = board.duplicateWall(downCellsouthWall)
+  expect(correspondingSouthWallCheck).toStrictEqual(true)
+
+  const leftCellEastWall = board.wallPositionsToCheck(Direction.East, { row: 5, column: 4 })
+  const correspondingEastWallCheck = board.duplicateWall(leftCellEastWall)
+  expect(correspondingEastWallCheck).toBe(true)
+  
+  const nonDuplicateWallsToCheck = board.wallPositionsToCheck(Direction.South, { row: 4, column: 4 });
+  const nonDuplicate = board.duplicateWall(nonDuplicateWallsToCheck);
+  expect(nonDuplicate).toBe(false);
+});
+
+  
+
+  

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -3,6 +3,7 @@ import { Robot } from '../board/robot';
 import { Direction } from '../board/direction';
  
 import type { Position } from '../board/position';
+import { BOARD_SIZE } from '../board/board';
 
 export class BoardBuilder {
   robots: [Robot, Position][];
@@ -11,6 +12,7 @@ export class BoardBuilder {
   constructor() {
     this.robots = []
     this.walls = []
+    this.generateRandomPairedWalls()
   }
 
   public withRobot(newRobot: Robot, newPosition: Position): BoardBuilder {
@@ -36,6 +38,39 @@ export class BoardBuilder {
     }
 
     return this;
+  }
+
+  public generateRandomPairedWalls() {
+    const wallsNorthSouth = [Direction.North, Direction.South]
+    const wallsEastWest = [Direction.West, Direction.East]
+
+    // NW
+    this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, 1,  BOARD_SIZE / 2 - 1, 1, BOARD_SIZE / 2 - 1)
+    // SW
+    this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, BOARD_SIZE / 2, BOARD_SIZE - 2, 1, BOARD_SIZE / 2 - 1)
+    // NE
+    this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, 1, BOARD_SIZE / 2 - 1, BOARD_SIZE / 2, BOARD_SIZE - 2)
+    // SE
+    this.placePairWallsInQuadrant(wallsNorthSouth,wallsEastWest, BOARD_SIZE / 2, BOARD_SIZE - 2, BOARD_SIZE / 2, BOARD_SIZE - 2)
+    console.log(this.walls)
+    return this
+  }
+
+  private placePairWallsInQuadrant(wallsNS: Direction[], wallsEW: Direction[], rowStart: number, colStart: number, rowEnd: number, colEnd: number) {
+    {
+      for (let i = 0; i < 3; i++) {
+        const randomRow = this.getRandomInt(rowStart, rowEnd );
+        const randomCol = this.getRandomInt(colStart, colEnd);
+        const randomIdx1 = Math.floor(Math.random() * wallsNS.length);
+        const randomIdx2 = Math.floor(Math.random() * wallsEW.length);
+    
+        this.withWall(wallsNS[randomIdx1]!,{ row: randomRow, column: randomCol }).withWall(wallsEW[randomIdx2]!, { row: randomRow, column: randomCol });
+      }
+    }
+  }
+
+  private getRandomInt(min: number, max: number):number {
+    return Math.floor(Math.random() * (max - min + 1) + min)
   }
 
   private addWalls(board: Board) {
@@ -68,7 +103,6 @@ export class BoardBuilder {
 
   public build() {
     let board = new Board();
-
     this.addWalls(board);
     this.addRobots(board);
 

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -53,6 +53,46 @@ export class BoardBuilder {
     return this
   }
 
+  generateRandomEdgeWalls() {
+
+    this.placeEdgeWallsNS(0, BOARD_SIZE / 2 - 2, 0)
+    this.placeEdgeWallsNS(0, BOARD_SIZE / 2 - 2, BOARD_SIZE -1 ) 
+    this.placeEdgeWallsNS(BOARD_SIZE/2, BOARD_SIZE - 2, 0)
+    this.placeEdgeWallsNS(BOARD_SIZE/2, BOARD_SIZE - 2,BOARD_SIZE -1) 
+
+    this.placeEdgeWallsEW(0, BOARD_SIZE / 2 - 2, 0)
+    this.placeEdgeWallsEW(0, BOARD_SIZE / 2 - 2, BOARD_SIZE -1)
+    this.placeEdgeWallsEW(BOARD_SIZE / 2, BOARD_SIZE - 2, 0)
+    this.placeEdgeWallsEW(BOARD_SIZE / 2, BOARD_SIZE - 2, BOARD_SIZE -1)
+
+  }
+
+  private placeEdgeWallsEW(rowStart: number, rowEnd: number, column: number) {
+    
+    while (true) {
+      const randomRow = this.getRandomInt(rowStart, rowEnd);
+      const collisionsToCheck = this.wallPositionsToCheck(Direction.South, { row: randomRow, column })
+      
+      if (!this.duplicateWall(collisionsToCheck)) {
+        this.withWall(Direction.South, { row: randomRow, column })
+        break
+      }
+    }
+  }
+  private placeEdgeWallsNS(colStart: number, colEnd: number, row: number) {
+    while (true) {
+
+      const randomCol = this.getRandomInt(colStart, colEnd);
+      const collisionsToCheck = this.wallPositionsToCheck(Direction.South, { row, column: randomCol,  })
+      
+      if (!this.duplicateWall(collisionsToCheck)) {
+        this.withWall(Direction.East, { row, column: randomCol })
+        break
+      }
+
+    }
+  }
+
   private placePairWallsInQuadrant( rowStart: number, colStart: number, rowEnd: number, colEnd: number) {
     {
       const wallsNS = [Direction.North, Direction.South]

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -12,7 +12,6 @@ export class BoardBuilder {
   constructor() {
     this.robots = []
     this.walls = []
-    this.generateRandomPairedWalls()
   }
 
   public withRobot(newRobot: Robot, newPosition: Position): BoardBuilder {

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -40,23 +40,23 @@ export class BoardBuilder {
   }
 
   public generateRandomPairedWalls() {
-    const wallsNorthSouth = [Direction.North, Direction.South]
-    const wallsEastWest = [Direction.West, Direction.East]
-
+    
     // NW
-    this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, 1,  BOARD_SIZE / 2 - 1, 1, BOARD_SIZE / 2 - 1)
+    this.placePairWallsInQuadrant(1,  BOARD_SIZE / 2 - 1, 1, BOARD_SIZE / 2 - 1)
     // SW
-    this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, BOARD_SIZE / 2, BOARD_SIZE - 2, 1, BOARD_SIZE / 2 - 1)
+    this.placePairWallsInQuadrant( BOARD_SIZE / 2, BOARD_SIZE - 2, 1, BOARD_SIZE / 2 - 1)
     // NE
-    this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, 1, BOARD_SIZE / 2 - 1, BOARD_SIZE / 2, BOARD_SIZE - 2)
+    this.placePairWallsInQuadrant( 1, BOARD_SIZE / 2 - 1, BOARD_SIZE / 2, BOARD_SIZE - 2)
     // SE
-    this.placePairWallsInQuadrant(wallsNorthSouth,wallsEastWest, BOARD_SIZE / 2, BOARD_SIZE - 2, BOARD_SIZE / 2, BOARD_SIZE - 2)
+    this.placePairWallsInQuadrant(BOARD_SIZE / 2, BOARD_SIZE - 2, BOARD_SIZE / 2, BOARD_SIZE - 2)
 
     return this
   }
 
-  private placePairWallsInQuadrant(wallsNS: Direction[], wallsEW: Direction[], rowStart: number, colStart: number, rowEnd: number, colEnd: number) {
+  private placePairWallsInQuadrant( rowStart: number, colStart: number, rowEnd: number, colEnd: number) {
     {
+      const wallsNS = [Direction.North, Direction.South]
+      const wallsEW = [Direction.West, Direction.East]
       for (let i = 0; i < 3; i++) {
         const randomRow = this.getRandomInt(rowStart, rowEnd );
         const randomCol = this.getRandomInt(colStart, colEnd);

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -51,7 +51,7 @@ export class BoardBuilder {
     this.placePairWallsInQuadrant(wallsNorthSouth, wallsEastWest, 1, BOARD_SIZE / 2 - 1, BOARD_SIZE / 2, BOARD_SIZE - 2)
     // SE
     this.placePairWallsInQuadrant(wallsNorthSouth,wallsEastWest, BOARD_SIZE / 2, BOARD_SIZE - 2, BOARD_SIZE / 2, BOARD_SIZE - 2)
-    console.log(this.walls)
+
     return this
   }
 
@@ -62,10 +62,57 @@ export class BoardBuilder {
         const randomCol = this.getRandomInt(colStart, colEnd);
         const randomIdx1 = Math.floor(Math.random() * wallsNS.length);
         const randomIdx2 = Math.floor(Math.random() * wallsEW.length);
-    
-        this.withWall(wallsNS[randomIdx1]!,{ row: randomRow, column: randomCol }).withWall(wallsEW[randomIdx2]!, { row: randomRow, column: randomCol });
+
+        const nsWallCheck = this.wallPositionsToCheck(wallsNS[randomIdx1]!, { row: randomRow, column: randomCol });
+        const ewWallCheck = this.wallPositionsToCheck(wallsEW[randomIdx2]!, { row: randomRow, column: randomCol });
+
+        if (!this.duplicateWall(nsWallCheck) && !this.duplicateWall(ewWallCheck)) {
+            this.withWall(wallsNS[randomIdx1]!, { row: randomRow, column: randomCol })
+            .withWall(wallsEW[randomIdx2]!, { row: randomRow, column: randomCol })
+          }
+          else {
+            i -= 1
+        }  
       }
     }
+  }
+
+  wallPositionsToCheck(wallDirection: Direction,positionProspect: Position) {
+    const postitionsToCheck: [Direction, Position][] = []
+    postitionsToCheck.push([wallDirection, positionProspect])
+    
+    switch(wallDirection) {
+      case Direction.North:
+        postitionsToCheck.push([Direction.South ,{ row: positionProspect.row - 1, column: positionProspect.column }]);
+        break;
+      case Direction.South:
+        postitionsToCheck.push([Direction.North, { row: positionProspect.row + 1, column: positionProspect.column }]);
+        break
+      case Direction.East:
+        postitionsToCheck.push([Direction.West ,{ row: positionProspect.row, column: positionProspect.column + 1 }]);
+        break;
+      case Direction.West:
+        postitionsToCheck.push([Direction.East ,{ row: positionProspect.row, column: positionProspect.column - 1 }]);;
+        break;
+    }
+    return postitionsToCheck
+  }
+
+  duplicateWall(postitionsToCheck: [Direction, Position][]) {
+    
+    for (let [wallDirection, { row, column }] of postitionsToCheck) {
+      const alreadyExists = this.walls.some(([existingDirection, existingPosition]) => {
+        return (
+          existingDirection === wallDirection
+          && row === existingPosition.row
+          && column === existingPosition.column
+        )
+      })
+      if (alreadyExists) {
+        return true
+      }
+    }
+    return false 
   }
 
   private getRandomInt(min: number, max: number):number {


### PR DESCRIPTION
This pull request introduces functionality to generate random paired walls and edge walls for the board in an evenly distributed manner. It includes methods to randomly place edge walls and paired walls in each quadrant of the game board, while ensuring that new wall placements do not collide with existing walls. 

Wall Generation Logic:
- Implemented the `generateRandomPairedWalls` method to place three paired walls in all four quadrants (NW, SW, NE, SE) of the game board.
- Implemented  `generateRandomEdgeWalls `method to place one wall along each half of the board's edges for balanced wall distribution
- Created` placePairWallsInQuadrant`, `placeEdgeWallsEW` and `placeEdgeWallsNS`  to handle random placement of walls within a specified quadrant or side of the board

Collision Detection:
- Implemented `wallPositionsToCheck` to determine adjacent cell to check based on wall direction and proposed positions.
- Added `duplicateWall` method to check for an existing wall in the proposed positions before placing new walls.

Utility Functions:
- Added `getRandomInt` to generate random integers within a specified range for wall placement.

Testing:
- Created tests for `wallPositionsToCheck` and `duplicateWall`