### PR TITLE
Bug Fixes: Camera was getting reoriented and initial target cell rend…

### DIFF
--- a/frontend/src/board/board.ts
+++ b/frontend/src/board/board.ts
@@ -35,8 +35,6 @@ export class Board {
     cells[8][7].isObstructed = true;
     cells[8][8].isObstructed = true;
 
- 
-
     this.cells = cells;
     this.robots = [
       new Robot(Color.Blue),
@@ -76,6 +74,10 @@ export class Board {
   }
    
   findTargetCell() {
+    if (!this.cells || this.cells.length === 0) {
+      console.error("Error: Grid is not initialized properly.");
+      return null;
+  }
     for (let row = 0; row < this.cells.length; row++) {
       if (this.cells[row]) {
         const len = this.cells[row]!.length
@@ -177,8 +179,7 @@ export class Board {
     const openPositions = []
     for (let row = 0; row < boardSize; row++) {
       for (let col = 0; col < boardSize; col++) {
-        // if cell is not obstructed add position
-
+        
         if (!this.cells[row]![col]?.isObstructed && !this.cells[row]![col]?.isTarget) {
           openPositions.push({ row: row, column: col })
         }

--- a/frontend/src/game/gameController.ts
+++ b/frontend/src/game/gameController.ts
@@ -44,7 +44,8 @@ export class GameController {
         this.boardHistory = new RobotStateHistory()
         const newBoard = new BoardBuilder()
         this.board = newBoard.buildRandom()
-        this.sceneController.updateBoardPositions(this.board)     
+        this.sceneController.updateBoardPositions(this.board
+        )     
         
     }
 

--- a/frontend/src/scene/points/targetChip.ts
+++ b/frontend/src/scene/points/targetChip.ts
@@ -21,9 +21,9 @@ export default class targetChipPiece {
         
         this.bufferGeometry = new THREE.BufferGeometry()
         const positions = new Float32Array(15)
-        const x = (this.position.row) - 7.5
+        const x = (this.position.column) - 7.5
         const y = .2
-        const z = (this.position.column) - 7.5
+        const z = (this.position.row) - 7.5
         positions[0] = x
         positions[1] = y
         positions[2] = z

--- a/frontend/src/scene/sceneController.ts
+++ b/frontend/src/scene/sceneController.ts
@@ -121,18 +121,7 @@ export class SceneController {
                 this.placeTargetChip(targetCell)
             }
         }
-        this.cells.forEach((cell,index) => {
-            
-            gsap.to((cell.material as THREE.MeshBasicMaterial) .color, {
-                r: Math.random(),
-                g: .05,
-                b: .9,
-                duration: 1.5,
-                repeat: 1,
-                yoyo: true,
-                delay: (index * 0.001) 
-            });
-        })
+        
         tl.call(() => {
             this.placeRobots(board);
             this.updateWallPositions(board)
@@ -141,23 +130,21 @@ export class SceneController {
         })
         
         tl.to(this.camera.position, {
-            x: 50,
-            y: 0,
+            x: 0,
+            y: 50,
             z: 0,
-            duration: 1
+            duration: 1,
+            ease: 'circle'
         })
-        
         tl.to(this.camera.position, {
             x: 0,
-            y: 14,
+            y: 15,
             z: 0,
             duration: 2,
-            ease: 'bounce',
-            onUpdate: () => {
-                this.camera.lookAt(new THREE.Vector3(0, 0, 0))
-            }
+        
+            ease: 'bounce'
         })
-
+        
         
         this.cells.forEach((cell, index) => {
             const randomInt1 = Math.random()/4
@@ -168,15 +155,13 @@ export class SceneController {
                 r: newTargetColorRGB.r+randomInt1,
                 g: newTargetColorRGB.g+randomInt2,
                 b: newTargetColorRGB.b+randomInt3,
-                duration: .2,
+                duration: 1.5,
                 repeat: 1,
                 yoyo: true,
                 ease: 'circle',
-                delay: (index * 0.0009) + 3
+                delay: (index * 0.005) 
             });
        })
-       
-       
     }
 
     private updateWallPositions(board: Board) {

--- a/frontend/src/util/boardBuilder.ts
+++ b/frontend/src/util/boardBuilder.ts
@@ -286,7 +286,6 @@ export class BoardBuilder {
    
   public build() {
     let board = new Board();
-  
     this.addWalls(board);
     this.addRobots(board);
     this.addTargetCell(board)
@@ -300,7 +299,6 @@ export class BoardBuilder {
     this.addWalls(board);
     this.addRobots(board);
     this.addTargetCell(board)
-    
 
     return board;
   }


### PR DESCRIPTION
…ered in incorrect position

- Camera animations now don't change camera orientation, preventing board flip that was causing the pieces to look like there were rendered twice
- initial targetChip position was flipped